### PR TITLE
V0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ vendor
 
 
 temp.php
-src/DBMS.php
-src/JoinClauseTypes.php
+src/Enums/DBMS.php
+src/Enums/JoinClauseTypes.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .idea
 composer.lock
-coverage-reports
+build
 vendor
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
   - ./vendor/bin/phpunit --testsuite=unit --coverage-text --coverage-clover build/logs/clover.xml
 
 after_script:
-  - if [ $(phpenv version-name) = "7.1" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+  - if [ $(phpenv version-name) >= "7.1" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 script:
   - ./vendor/bin/phpcs src
   - ./vendor/bin/psalm
-  - ./vendor/bin/phpunit --testsuite=unit --coverage-text --coverage-clover build/logs/clover.xml
+  - ./vendor/bin/phpunit --coverage-text
 
 after_script:
   - if [ $(phpenv version-name) >= "7.1" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
-  - if [ $(phpenv version-name) >= "7.1" ]; then ./cc-test-reporter before-build; fi
+  - if [ $(phpenv version-name) = "7.1" ]; then ./cc-test-reporter before-build; fi
 
 install:
   - composer selfupdate
@@ -25,4 +25,4 @@ script:
   - ./vendor/bin/phpunit --coverage-text
 
 after_script:
-  - if [ $(phpenv version-name) >= "7.1" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+  - if [ $(phpenv version-name) = "7.1" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=44a54e4dea6cb58bb7af1da3dfd30b384af6218d0717058972ed3fa17393f555
+    - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
+
 language: php
 
 php:
   - 7.1
   - 7.2
   - 7.3
+
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - if [ $(phpenv version-name) >= "7.1" ]; then ./cc-test-reporter before-build; fi
 
 install:
   - composer selfupdate
@@ -12,7 +22,7 @@ install:
 script:
   - ./vendor/bin/phpcs src
   - ./vendor/bin/psalm
-  - ./vendor/bin/phpunit --colors --coverage-text
+  - ./vendor/bin/phpunit --testsuite=unit --coverage-text --coverage-clover build/logs/clover.xml
 
-after_success:
-  - travis_retry php vendor/bin/coveralls
+after_script:
+  - if [ $(phpenv version-name) = "7.1" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ composer require girgias/query-builder
 This Query Builder can build a variety of SQL queries which are database agnostic
 because it uses the ANSI standardized syntax.
 
+Every sort of query has its own class which extends from the base Query class,
+They all have the same constructor signature which requires the table name 
+on which to execute the query.
+
 ### Examples
 A basic select query:
 ```php
@@ -78,7 +82,6 @@ There are some features that are still waiting to be implementing
 
 * WHERE IN and WHERE NOT IN clauses
 * Table joins
-* Warns when using a LIMIT clause without an ORDER clause
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ because it uses the ANSI standardized syntax.
 ### Examples
 A basic select query:
 ```php
-$query = (new \Girgias\QueryBuilder\Query('select', 'demo')
+$query = (new \Girgias\QueryBuilder\Select("demo"))
     ->limit(10, 20)
-    ->order('published_date')
+    ->order("published_date")
     ->getQuery();
 ```
 Will output:
@@ -29,15 +29,15 @@ SELECT * FROM demo ORDER BY published_date ASC LIMIT 10 OFFSET 20
 
 A more complex select query:
 ```php
-$start = new \DateTime('01/01/2016');
-$end   = new \DateTime('01/01/2017');
-$query = (new \Girgias\QueryBuilder\Query('select', 'demo'))
-        ->select('title', 'slug')
-        ->selectAs('name_author_post', 'author')
-        ->whereBetween('date_published', $start, $end)
-        ->order('date_published', 'DESC')
-        ->limit(25)
-        ->getQuery();
+$start = new \DateTime("01/01/2016");
+$end   = new \DateTime("01/01/2017");
+$query = (new \Girgias\QueryBuilder\Select("demo"))
+    ->select("title", "slug")
+    ->selectAs("name_author_post", "author")
+    ->whereBetween("date_published", $start, $end)
+    ->order("date_published", "DESC")
+    ->limit(25)
+    ->getQuery();
 ```
 
 Will output:
@@ -47,10 +47,10 @@ SELECT title, slug, name_author_post AS author FROM demo WHERE date_published BE
 
 An example with the ``whereOr`` method:
 ```php
-$query = (new \Girgias\QueryBuilder\Query('select', 'demo'))
-        ->where('author', 'author')
-        ->whereOr('editor', 'editor')
-        ->getQuery();
+$query = (new \Girgias\QueryBuilder\Select("demo"))
+    ->where("author", "=", "author")
+    ->whereOr("editor", "=", "editor")
+    ->getQuery();
 ```
 
 Will output:
@@ -60,11 +60,11 @@ SELECT * FROM demo WHERE (author = :author OR editor = :editor)
 
 Update example:
 ```php
-$query = (new \Girgias\QueryBuilder\Query(Query::QUERY_UPDATE, 'posts'))
-    ->where('id', SqlOperators::EQUAL, 'id')
-    ->bindField('title', 'title')
-    ->bindField('content', 'content')
-    ->bindField('date_last_edited', 'now_date')
+$query = (new \Girgias\QueryBuilder\Update("posts"))
+    ->where("id", SqlOperators::EQUAL, "id")
+    ->bindField("title", "title")
+    ->bindField("content", "content")
+    ->bindField("date_last_edited", "now_date")
     ->getQuery();
 ```
 Will output:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SQL Query Builder
+[![Build Status](https://travis-ci.org/Girgias/query-builder.svg?branch=master)](https://travis-ci.org/Girgias/query-builder)
 
 A fluent SQL Query Builder which **ONLY** builds a valid SQL query with the SQL 
 clauses it has been asked to provide.
@@ -86,26 +87,30 @@ There are some features that are still waiting to be implementing
 ## Contributing
 
 If you found an invalid SQL name which **DOESN'T** throw a Runtime exception
-or a valid SQL name which does
-please add a test case into the ``tests/CheckSqlNamesTest.php`` file.
+or a valid SQL name which does please add a test case into the 
+``tests/CheckSqlNamesTest.php`` file.
 
 If you found an example where this library returns an invalid SQL query
 please add (or fix) a test case in the ``tests/QueryTest`` file.
+
 If a RunTime exception should be thrown please add a test in the 
 ``tests/QueryThrowExceptionsTest.php`` file.
 
 If you'd like to contribute, please fork the repository and use a feature
 branch. Pull requests are warmly welcome.
 
-Note: When contributing you should make sure that Psalm doesn't return an error
+### Notes
+When contributing you should make sure that Psalm runs without error
 and all unit tests pass.
+Moreover if you add functionality please add corresponding unit tests to cover
+at least 90% of your code and that theses tests make sure of edge cases if they exist.
 
 ## Links
 
 - Repository: https://github.com/girgias/query-builder/
 - Issue tracker: https://github.com/girgias/query-builder/issues
   - In case of sensitive bugs like security vulnerabilities, please contact
-    george.banyard@gmail.com directly instead of using issue tracker.
+    george.banyard@gmail.com directly instead of using the issue tracker.
 
 
 ## Licensing

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,7 +13,6 @@
     <rule ref="Squiz.Arrays.ArrayBracketSpacing" />
     <rule ref="Squiz.Commenting.DocCommentAlignment" />
     <rule ref="Squiz.Commenting.EmptyCatchComment" />
-    <rule ref="Squiz.Commenting.InlineComment" />
     <rule ref="Squiz.Commenting.PostStatementComment" />
     <rule ref="Squiz.Formatting.OperatorBracket" />
     <rule ref="Squiz.PHP.DisallowInlineIf" />

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,4 +25,7 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,7 @@
 >
     <testsuites>
         <testsuite name="unit">
-            <directory phpVersion="7.3" >tests</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,7 +15,7 @@
         verbose="false"
 >
     <testsuites>
-        <testsuite name="tests">
+        <testsuite name="unit">
             <directory phpVersion="7.3" >tests</directory>
         </testsuite>
     </testsuites>

--- a/src/Delete.php
+++ b/src/Delete.php
@@ -1,0 +1,28 @@
+<?php
+namespace Girgias\QueryBuilder;
+
+use Girgias\QueryBuilder\Exceptions\DangerousSqlQueryWarning;
+
+class Delete extends Query
+{
+
+    /**
+     * Return built Query
+     *
+     * @return string
+     */
+    public function getQuery(): string
+    {
+        if (is_null($this->where)) {
+            throw new DangerousSqlQueryWarning('No WHERE clause in DELETE FROM query');
+        }
+
+        $parts = ['DELETE FROM'];
+        $parts[] = $this->table;
+
+        $parts[] = 'WHERE';
+        $parts[] = join(' AND ', $this->where);
+
+        return join(' ', $parts);
+    }
+}

--- a/src/Enums/AggregateFunctions.php
+++ b/src/Enums/AggregateFunctions.php
@@ -1,5 +1,5 @@
 <?php
-namespace Girgias\QueryBuilder;
+namespace Girgias\QueryBuilder\Enums;
 
 /**
  * Class AggregateFunctions

--- a/src/Enums/BasicEnum.php
+++ b/src/Enums/BasicEnum.php
@@ -6,9 +6,7 @@
 
 namespace Girgias\QueryBuilder\Enums;
 
-use DomainException;
 use ReflectionClass;
-use ReflectionException;
 
 /**
  * Class BasicEnum
@@ -35,6 +33,7 @@ abstract class BasicEnum
     {
     }
 
+    /** @noinspection PhpDocMissingThrowsInspection */
     /**
      * @return array<string, mixed>
      */
@@ -44,17 +43,13 @@ abstract class BasicEnum
             self::$constCacheArray = [];
         }
 
-        $calledClass = get_called_class();
-        if (array_key_exists($calledClass, self::$constCacheArray) === false) {
-            try {
-                $reflect = new ReflectionClass($calledClass);
-                self::$constCacheArray[$calledClass] = $reflect->getConstants();
-            } catch (ReflectionException $exception) {
-                throw new DomainException('Unable to retrieve Enum constants', 0, $exception);
-            }
+        if (array_key_exists(static::class, self::$constCacheArray) === false) {
+            /** @noinspection PhpUnhandledExceptionInspection*/
+            $reflect = new ReflectionClass(static::class);
+            self::$constCacheArray[static::class] = $reflect->getConstants();
         }
 
-        return self::$constCacheArray[$calledClass];
+        return self::$constCacheArray[static::class];
     }
 
     /**

--- a/src/Enums/BasicEnum.php
+++ b/src/Enums/BasicEnum.php
@@ -4,7 +4,7 @@
  * Edited and updated by George Peter Banyard <george.banyard@gmail.com>
  */
 
-namespace Girgias\QueryBuilder;
+namespace Girgias\QueryBuilder\Enums;
 
 use DomainException;
 use ReflectionClass;

--- a/src/Enums/SqlOperators.php
+++ b/src/Enums/SqlOperators.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Girgias\QueryBuilder;
+namespace Girgias\QueryBuilder\Enums;
 
 /**
  * Class SqlOperators

--- a/src/Enums/SqlReservedWords.php
+++ b/src/Enums/SqlReservedWords.php
@@ -1,5 +1,5 @@
 <?php
-namespace Girgias\QueryBuilder;
+namespace Girgias\QueryBuilder\Enums;
 
 class SqlReservedWords
 {

--- a/src/Exceptions/InvalidSqlTableNameException.php
+++ b/src/Exceptions/InvalidSqlTableNameException.php
@@ -13,7 +13,6 @@ class InvalidSqlTableNameException extends InvalidArgumentException
 {
     /**
      * InvalidSqlTableNameException constructor.
-     * @param string $clause
      * @param string $table
      * @param int $code
      * @param Throwable|null $previous

--- a/src/Exceptions/UnexpectedSqlOperatorException.php
+++ b/src/Exceptions/UnexpectedSqlOperatorException.php
@@ -21,7 +21,7 @@ class UnexpectedSqlOperatorException extends UnexpectedValueException
     {
         $message = "Comparison operator `{$operator}` provided for {$clause} clause is invalid or unsupported.";
         if ($operator === "!=") {
-            $message .= "Did you mean `<>` (ANSI 'not equal to' operator) ?";
+            $message .= "\nDid you mean `<>` (ANSI 'not equal to' operator) ?";
         }
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exceptions/UnexpectedSqlOperatorException.php
+++ b/src/Exceptions/UnexpectedSqlOperatorException.php
@@ -20,6 +20,9 @@ class UnexpectedSqlOperatorException extends UnexpectedValueException
     public function __construct(string $clause, string $operator, int $code = 0, ?Throwable $previous = null)
     {
         $message = "Comparison operator `{$operator}` provided for {$clause} clause is invalid or unsupported.";
+        if ($operator === "!=") {
+            $message .= "Did you mean `<>` (ANSI 'not equal to' operator) ?";
+        }
         parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Exceptions/UnexpectedSqlOperatorException.php
+++ b/src/Exceptions/UnexpectedSqlOperatorException.php
@@ -13,13 +13,13 @@ class UnexpectedSqlOperatorException extends UnexpectedValueException
     /**
      * UndefinedSqlOperatorException constructor.
      * @param string $clause
-     * @param string $function
+     * @param string $operator
      * @param int $code
      * @param Throwable|null $previous
      */
-    public function __construct(string $clause, string $function, int $code = 0, ?Throwable $previous = null)
+    public function __construct(string $clause, string $operator, int $code = 0, ?Throwable $previous = null)
     {
-        $message = "Comparison operator `{$function}` provided for {$clause} clause is invalid or unsupported.";
+        $message = "Comparison operator `{$operator}` provided for {$clause} clause is invalid or unsupported.";
         parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Insert.php
+++ b/src/Insert.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Girgias\QueryBuilder;
+
+use RuntimeException;
+
+class Insert extends Query
+{
+
+    /**
+     * Return built Query
+     *
+     * @return string
+     */
+    final public function getQuery(): string
+    {
+        if (is_null($this->parameter)) {
+            throw new RuntimeException("No fields to update defined");
+        }
+
+        $parts = ['INSERT INTO'];
+        $parts[] = $this->table;
+
+        $columns = [];
+        foreach (array_keys($this->parameter) as $keys) {
+            $columns[] = $keys;
+        }
+        $parts[] = '(' . join(', ', $columns) . ')';
+
+        $parts[] = 'VALUES';
+
+        $parameters = [];
+        foreach ($this->parameter as $parameter) {
+            $parameters[] = ':' . $parameter;
+        }
+        $parts[] = '(' . join(', ', $parameters) . ')';
+
+        return join(' ', $parts);
+    }
+}

--- a/src/Insert.php
+++ b/src/Insert.php
@@ -15,7 +15,7 @@ class Insert extends Query
     final public function getQuery(): string
     {
         if (is_null($this->parameter)) {
-            throw new RuntimeException("No fields to update defined");
+            throw new RuntimeException('No fields to update defined');
         }
 
         $parts = ['INSERT INTO'];

--- a/src/Query.php
+++ b/src/Query.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 namespace Girgias\QueryBuilder;
 
 use DateTimeInterface;
-use DomainException;
-use Girgias\QueryBuilder\Exceptions\InvalidSqlAliasNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlColumnNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlFieldNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlTableNameException;
 use Girgias\QueryBuilder\Exceptions\UnexpectedSqlOperatorException;
 use Girgias\QueryBuilder\Exceptions\UnexpectedSqlFunctionException;
-use Girgias\QueryBuilder\Exceptions\DangerousSqlQueryWarning;
 use InvalidArgumentException;
-use OutOfRangeException;
 use RuntimeException;
 use TypeError;
 
@@ -21,13 +17,8 @@ use TypeError;
  * Class Query
  * @package Girgias\QueryBuilder
  */
-class Query
+abstract class Query
 {
-    public const QUERY_DELETE = "delete";
-    public const QUERY_INSERT = "insert";
-    public const QUERY_SELECT = "select";
-    public const QUERY_UPDATE = "update";
-
     public const SORT_ASC = "ASC";
     public const SORT_DESC = "DESC";
 
@@ -37,221 +28,36 @@ class Query
     /**
      * @var string
      */
-    private $queryType;
-
-    /**
-     * @var string
-     */
-    private $table;
-
-    /**
-     * @var ?string
-     */
-    private $tableAlias;
+    protected $table;
 
     /**
      * @var ?array<int, string>
      */
-    private $select;
-
-    /**
-     * @var bool
-     */
-    private $distinct = false;
+    protected $where;
 
     /**
      * @var ?array<int, string>
      */
-    private $where;
-
-    /**
-     * @var ?array<int, string>
-     */
-    private $group;
-
-    /**
-     * @var ?array<int, string>
-     */
-    private $having;
-
-    /**
-     * @var ?array<int, string>
-     */
-    private $order;
-
-    /**
-     * @var ?int
-     */
-    private $limit;
-
-    /**
-     * @var ?int
-     */
-    private $offset;
+    protected $having;
 
     /**
      * @var ?array<string, string>
      */
-    private $parameter;
+    protected $parameter;
 
     /**
      * Query constructor.
      *
-     * @param string $queryType
      * @param string $table
      */
-    public function __construct(string $queryType, string $table)
+    public function __construct(string $table)
     {
-        if ($queryType !== self::QUERY_DELETE &&
-            $queryType !== self::QUERY_INSERT &&
-            $queryType !== self::QUERY_SELECT &&
-            $queryType !== self::QUERY_UPDATE) {
-            throw new InvalidArgumentException("Query type {$queryType} is invalid.");
-        }
-
         if (!$this->isValidSqlName($table)) {
             throw new InvalidSqlTableNameException($table);
         }
 
-        $this->queryType = $queryType;
-
         $this->table = $table;
     }
-
-    /**
-     * SELECT Query functions
-     */
-
-    /**
-     * Set an alias for the table
-     *
-     * @param string $alias
-     * @return Query
-     */
-    final public function tableAlias(string $alias): self
-    {
-        if (!$this->isValidSqlName($alias)) {
-            throw new InvalidSqlAliasNameException('FROM', $alias);
-        }
-        $this->tableAlias = $alias;
-        return $this;
-    }
-
-    /**
-     * SELECT fields
-     *
-     * @param string ...$fields
-     * @return Query
-     */
-    final public function select(string ...$fields): self
-    {
-        foreach ($fields as $field) {
-            if (!$this->isValidSqlName($field)) {
-                throw new InvalidSqlFieldNameException($field);
-            }
-            $this->select[] = $field;
-        }
-        return $this;
-    }
-
-    /**
-     * SELECT a field with an alias
-     *
-     * @param string $field
-     * @param string $alias
-     * @return Query
-     */
-    final public function selectAs(string $field, string $alias): self
-    {
-        if (!$this->isValidSqlName($field)) {
-            throw new InvalidSqlFieldNameException($field);
-        }
-
-        if (!$this->isValidSqlName($alias)) {
-            throw new InvalidSqlAliasNameException($field, $alias);
-        }
-
-        $this->select[] = $field . ' AS ' . $alias;
-        return $this;
-    }
-
-    /**
-     * SELECT an aggregated field
-     *
-     * @param string $field
-     * @param string $aggregateFunction
-     * @param string $alias
-     * @return Query
-     */
-    final public function selectAggregate(string $field, string $aggregateFunction, string $alias): self
-    {
-        if (!$this->isValidSqlName($field)) {
-            throw new InvalidSqlFieldNameException($field);
-        }
-
-        if (!AggregateFunctions::isValidValue($aggregateFunction)) {
-            throw new UnexpectedSqlFunctionException('SELECT with aggregate function', $aggregateFunction);
-        }
-
-        if (!$this->isValidSqlName($alias)) {
-            throw new InvalidSqlAliasNameException($field, $alias);
-        }
-
-        $this->select[] = $aggregateFunction . '(' . $field . ') AS ' . $alias;
-        return $this;
-    }
-
-    /**
-     * SELECT DISTINCT fields
-     *
-     * @param string ...$fields
-     * @return Query
-     */
-    final public function distinct(string ...$fields): self
-    {
-        $this->distinct = true;
-        return $this->select(...$fields);
-    }
-
-    /**
-     * SELECT DISTINCT a field with an alias
-     *
-     * @param string $field
-     * @param string $alias
-     * @return Query
-     */
-    final public function distinctAs(string $field, string $alias): self
-    {
-        $this->distinct = true;
-        return $this->selectAs($field, $alias);
-    }
-
-    /**
-     * SELECT an aggregated DISTINCT field
-     *
-     * @param string $field
-     * @param string $aggregateFunction
-     * @param string $alias
-     * @return Query
-     */
-    final public function distinctAggregate(string $field, string $aggregateFunction, string $alias): self
-    {
-        if (!$this->isValidSqlName($field)) {
-            throw new InvalidSqlFieldNameException($field);
-        }
-
-        if (!AggregateFunctions::isValidValue($aggregateFunction)) {
-            throw new UnexpectedSqlFunctionException('SELECT DISTINCT with aggregate function', $aggregateFunction);
-        }
-
-        if (!$this->isValidSqlName($alias)) {
-            throw new InvalidSqlAliasNameException($field, $alias);
-        }
-
-        $this->select[] = $aggregateFunction . '(DISTINCT ' . $field . ') AS ' . $alias;
-        return $this;
-    }
-
 
     /**
      * Add a WHERE clause to the Query
@@ -380,22 +186,6 @@ class Query
     }
 
     /**
-     * Add a GROUP BY clause to the Query
-     *
-     * @param string $column
-     * @return Query
-     */
-    final public function group(string $column): self
-    {
-        if (!$this->isValidSqlName($column)) {
-            throw new InvalidSqlColumnNameException('GROUP BY', $column);
-        }
-
-        $this->group = [$column];
-        return $this;
-    }
-
-    /**
      * Add a HAVING clause to the Query
      *
      * @param string $column
@@ -463,59 +253,6 @@ class Query
     }
 
     /**
-     * Add an ORDER BY clause to the Query
-     *
-     * @param string $column
-     * @param string $order
-     * @return Query
-     */
-    final public function order(string $column, string $order = self::SORT_ASC): self
-    {
-        if (!$this->isValidSqlName($column)) {
-            throw new InvalidSqlColumnNameException('ORDER BY', $column);
-        }
-        if ($order !== self::SORT_ASC && $order !== self::SORT_DESC) {
-            throw new InvalidArgumentException('Order must be ' . self::SORT_ASC . ' or ' . self::SORT_DESC);
-        }
-
-        $this->order[] = $column . ' ' . $order;
-        return $this;
-    }
-
-    /**
-     * Add a LIMIT clause to the Query
-     *
-     * @param int $limit
-     * @param int|null $offset
-     * @return Query
-     */
-    final public function limit(int $limit, ?int $offset = null): self
-    {
-        if ($limit < 0) {
-            throw new OutOfRangeException('SQL LIMIT can\'t be less than 0');
-        }
-        $this->limit = $limit;
-        if (!is_null($offset)) {
-            $this->offset($offset);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Add an OFFSET clause to the Query
-     *
-     * @param int $offset
-     */
-    final private function offset(int $offset): void
-    {
-        if ($offset < 0) {
-            throw new OutOfRangeException('SQL OFFSET can\'t be less than 0');
-        }
-        $this->offset = $offset;
-    }
-
-    /**
      * Binds a field to a parameter
      *
      * @param string $field
@@ -538,159 +275,7 @@ class Query
      *
      * @return string
      */
-    final public function getQuery(): string
-    {
-        switch ($this->queryType) {
-            case self::QUERY_DELETE:
-                return $this->buildDeleteQuery();
-            case self::QUERY_INSERT:
-                return $this->buildInsertQuery();
-            case self::QUERY_SELECT:
-                return $this->buildSelectQuery();
-            case self::QUERY_UPDATE:
-                return $this->buildUpdateQuery();
-        }
-        throw new DomainException('No valid query type to generate query');
-    }
-
-    /**
-     * Build DELETE query from parameters
-     *
-     * @return string
-     */
-    final private function buildDeleteQuery(): string
-    {
-        if (is_null($this->where)) {
-            throw new DangerousSqlQueryWarning('No WHERE clause in DELETE FROM query');
-        }
-
-        $parts = ['DELETE FROM'];
-        $parts[] = $this->table;
-
-        $parts[] = 'WHERE';
-        $parts[] = join(' AND ', $this->where);
-
-        return join(' ', $parts);
-    }
-
-    /**
-     * Build INSERT INTO query from parameters
-     *
-     * @return string
-     */
-    final private function buildInsertQuery(): string
-    {
-        if (is_null($this->parameter)) {
-            throw new RuntimeException("No fields to update defined");
-        }
-
-        $parts = ['INSERT INTO'];
-        $parts[] = $this->table;
-
-        $columns = [];
-        foreach (array_keys($this->parameter) as $keys) {
-            $columns[] = $keys;
-        }
-        $parts[] = '(' . join(', ', $columns) . ')';
-
-        $parts[] = 'VALUES';
-
-        $parameters = [];
-        foreach ($this->parameter as $parameter) {
-            $parameters[] = ':' . $parameter;
-        }
-        $parts[] = '(' . join(', ', $parameters) . ')';
-
-        return join(' ', $parts);
-    }
-
-    /**
-     * Build SELECT query from parameters
-     *
-     * @return string
-     */
-    final private function buildSelectQuery(): string
-    {
-        if (is_null($this->select)) {
-            $this->select[] = '*';
-        }
-        $parts = ['SELECT'];
-        if ($this->distinct) {
-            $parts[] = 'DISTINCT';
-        }
-        $parts[] = join(', ', $this->select);
-
-        $parts[] = 'FROM';
-        $parts[] = $this->table;
-
-        if (!is_null($this->tableAlias)) {
-            $parts[] = 'AS';
-            $parts[] = $this->tableAlias;
-        }
-
-        if (!is_null($this->where)) {
-            $parts[] = 'WHERE';
-            $parts[] = join(' AND ', $this->where);
-        }
-
-        if (!is_null($this->group)) {
-            $parts[] = 'GROUP BY';
-            $parts[] = join(' ', $this->group);
-        }
-
-        if (!is_null($this->having)) {
-            $parts[] = 'HAVING';
-            $parts[] = join(' AND ', $this->having);
-        }
-
-        if (!is_null($this->order)) {
-            $parts[] = 'ORDER BY';
-            $parts[] = join(', ', $this->order);
-        }
-
-        if (!is_null($this->limit)) {
-            $parts[] = 'LIMIT';
-            $parts[] = $this->limit;
-        }
-
-        if (!is_null($this->offset)) {
-            $parts[] = 'OFFSET';
-            $parts[] = $this->offset;
-        }
-
-        return join(' ', $parts);
-    }
-
-    /**
-     * Build UPDATE query from parameters
-     *
-     * @return string
-     */
-    final private function buildUpdateQuery(): string
-    {
-        if (is_null($this->parameter)) {
-            throw new RuntimeException("No fields to update defined");
-        }
-        if (is_null($this->where)) {
-            throw new DangerousSqlQueryWarning('No WHERE clause in UPDATE query');
-        }
-
-        $parts = ['UPDATE'];
-        $parts[] = $this->table;
-        $parts[] = 'SET';
-
-        $columns = [];
-        
-        foreach ($this->parameter as $column => $binding) {
-            $columns[] = $column . ' = :' . $binding;
-        }
-        $parts[] = join(', ', $columns);
-
-        $parts[] = 'WHERE';
-        $parts[] = join(' AND ', $this->where);
-
-        return join(' ', $parts);
-    }
+    abstract public function getQuery(): string;
 
     /**
      * Checks if argument is a valid SQL name
@@ -698,7 +283,7 @@ class Query
      * @param string $name
      * @return bool
      */
-    final private function isValidSqlName(string $name): bool
+    final protected function isValidSqlName(string $name): bool
     {
         if (preg_match(self::SQL_NAME_PATTERN, $name) === 1 &&
             !in_array(strtoupper($name), SqlReservedWords::RESERVED_WORDS)

--- a/src/Query.php
+++ b/src/Query.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Girgias\QueryBuilder;
 
 use DateTimeInterface;
+use Girgias\QueryBuilder\Enums\SqlOperators;
+use Girgias\QueryBuilder\Enums\SqlReservedWords;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlColumnNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlFieldNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlTableNameException;

--- a/src/Query.php
+++ b/src/Query.php
@@ -19,11 +19,11 @@ use TypeError;
  */
 abstract class Query
 {
-    public const SORT_ASC = "ASC";
-    public const SORT_DESC = "DESC";
+    public const SORT_ASC = 'ASC';
+    public const SORT_DESC = 'DESC';
 
-    protected const SQL_NAME_PATTERN = "#^[a-z_]+(.[a-z0-9_])*$#";
-    protected const SQL_DATE_FORMAT = "Y-m-d H:i:s";
+    protected const SQL_NAME_PATTERN = '#^[a-z_]+(.[a-z0-9_])*$#';
+    protected const SQL_DATE_FORMAT = 'Y-m-d H:i:s';
 
     /**
      * @var string
@@ -316,7 +316,7 @@ abstract class Query
     final private function buildBetweenSqlString($start, $end): string
     {
         if (gettype($start) !== gettype($end)) {
-            throw new TypeError("Start and End values provided to WHERE NOT BETWEEN are of different types");
+            throw new TypeError('Start and End values provided to WHERE NOT BETWEEN are of different types');
         }
 
         if (!is_int($start) && !is_float($start) && !($start instanceof DateTimeInterface) &&

--- a/src/Query.php
+++ b/src/Query.php
@@ -8,7 +8,6 @@ use Girgias\QueryBuilder\Exceptions\InvalidSqlColumnNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlFieldNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlTableNameException;
 use Girgias\QueryBuilder\Exceptions\UnexpectedSqlOperatorException;
-use Girgias\QueryBuilder\Exceptions\UnexpectedSqlFunctionException;
 use InvalidArgumentException;
 use RuntimeException;
 use TypeError;
@@ -34,11 +33,6 @@ abstract class Query
      * @var ?array<int, string>
      */
     protected $where;
-
-    /**
-     * @var ?array<int, string>
-     */
-    protected $having;
 
     /**
      * @var ?array<string, string>
@@ -181,73 +175,6 @@ abstract class Query
         }
 
         $this->where[] = $column . ' NOT BETWEEN ' . $this->buildBetweenSqlString($start, $end);
-
-        return $this;
-    }
-
-    /**
-     * Add a HAVING clause to the Query
-     *
-     * @param string $column
-     * @param string $aggregateFunction
-     * @param string $operator
-     * @param int $conditionValue
-     * @return Query
-     */
-    final public function having(string $column, string $aggregateFunction, string $operator, int $conditionValue): self
-    {
-        if (!$this->isValidSqlName($column)) {
-            throw new InvalidSqlColumnNameException('HAVING', $column);
-        }
-
-        if (!AggregateFunctions::isValidValue($aggregateFunction)) {
-            throw new UnexpectedSqlFunctionException('HAVING', $aggregateFunction);
-        }
-
-        if (!SqlOperators::isValidValue($operator)) {
-            throw new UnexpectedSqlOperatorException('HAVING', $operator);
-        }
-
-        $this->having[] = $aggregateFunction . '(' . $column . ') ' . $operator . ' ' . $conditionValue;
-
-        return $this;
-    }
-
-    /**
-     * Add a HAVING clause to the Query which should be ORed with the previous use of a HAVING clause
-     *
-     * @param string $column
-     * @param string $aggregateFunction
-     * @param string $operator
-     * @param int $conditionValue
-     * @return Query
-     */
-    final public function havingOr(
-        string $column,
-        string $aggregateFunction,
-        string $operator,
-        int $conditionValue
-    ): self {
-        if (!$this->isValidSqlName($column)) {
-            throw new InvalidSqlColumnNameException('HAVING', $column);
-        }
-
-        if (!AggregateFunctions::isValidValue($aggregateFunction)) {
-            throw new UnexpectedSqlFunctionException('HAVING', $aggregateFunction);
-        }
-
-        if (!SqlOperators::isValidValue($operator)) {
-            throw new UnexpectedSqlOperatorException('HAVING', $operator);
-        }
-
-        if (is_null($this->having)) {
-            throw new RuntimeException(
-                'Need to define at least another HAVING clause before utilizing havingOr method'
-            );
-        }
-
-        $this->having[] = '(' . array_pop($this->having) . ' OR ' .
-            $aggregateFunction . '(' . $column . ') ' . $operator . ' ' . $conditionValue . ')';
 
         return $this;
     }

--- a/src/Select.php
+++ b/src/Select.php
@@ -5,7 +5,6 @@ namespace Girgias\QueryBuilder;
 use Girgias\QueryBuilder\Exceptions\DangerousSqlQueryWarning;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlAliasNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlColumnNameException;
-use Girgias\QueryBuilder\Exceptions\InvalidSqlFieldNameException;
 use Girgias\QueryBuilder\Exceptions\UnexpectedSqlFunctionException;
 use InvalidArgumentException;
 use OutOfRangeException;
@@ -63,55 +62,55 @@ class Select extends Query
     }
 
     /**
-     * SELECT fields
+     * SELECT columns
      *
-     * @param string ...$fields
+     * @param string ...$columns
      * @return Select
      */
-    final public function select(string ...$fields): self
+    final public function select(string ...$columns): self
     {
-        foreach ($fields as $field) {
-            if (!$this->isValidSqlName($field)) {
-                throw new InvalidSqlFieldNameException($field);
+        foreach ($columns as $column) {
+            if (!$this->isValidSqlName($column)) {
+                throw new InvalidSqlColumnNameException('SELECT', $column);
             }
-            $this->select[] = $field;
+            $this->select[] = $column;
         }
         return $this;
     }
 
     /**
-     * SELECT a field with an alias
+     * SELECT a column with an alias
      *
-     * @param string $field
+     * @param string $column
      * @param string $alias
      * @return Select
      */
-    final public function selectAs(string $field, string $alias): self
+    final public function selectAs(string $column, string $alias): self
     {
-        if (!$this->isValidSqlName($field)) {
-            throw new InvalidSqlFieldNameException($field);
+        if (!$this->isValidSqlName($column)) {
+            throw new InvalidSqlColumnNameException('SELECT', $column);
         }
 
         if (!$this->isValidSqlName($alias)) {
-            throw new InvalidSqlAliasNameException($field, $alias);
+            throw new InvalidSqlAliasNameException($column, $alias);
         }
 
-        $this->select[] = $field . ' AS ' . $alias;
+        $this->select[] = $column . ' AS ' . $alias;
         return $this;
     }
 
     /**
-     * SELECT an aggregated field
+     * SELECT an aggregated column
      *
-     * @param string $field
+     * @param string $column
      * @param string $aggregateFunction
      * @param string $alias
      * @return Select
      */
-    final public function selectAggregate(string $field, string $aggregateFunction, string $alias): self
+    final public function selectAggregate(string $column, string $aggregateFunction, string $alias): self
     {
-        if (!$this->isValidSqlName($field)) {
-            throw new InvalidSqlFieldNameException($field);
+        if (!$this->isValidSqlName($column)) {
+            throw new InvalidSqlColumnNameException('SELECT', $column);
         }
 
         if (!AggregateFunctions::isValidValue($aggregateFunction)) {
@@ -119,10 +118,10 @@ class Select extends Query
         }
 
         if (!$this->isValidSqlName($alias)) {
-            throw new InvalidSqlAliasNameException($field, $alias);
+            throw new InvalidSqlAliasNameException($column, $alias);
         }
 
-        $this->select[] = $aggregateFunction . '(' . $field . ') AS ' . $alias;
+        $this->select[] = $aggregateFunction . '(' . $column . ') AS ' . $alias;
         return $this;
     }
 
@@ -138,42 +137,42 @@ class Select extends Query
 
 
     /**
-     * SELECT DISTINCT fields
+     * SELECT DISTINCT columns
      *
-     * @param string ...$fields
+     * @param string ...$columns
      * @return Select
      */
-    final public function distinct(string ...$fields): self
+    final public function distinct(string ...$columns): self
     {
         $this->distinct = true;
-        return $this->select(...$fields);
+        return $this->select(...$columns);
     }
 
     /**
-     * SELECT DISTINCT a field with an alias
+     * SELECT DISTINCT a column with an alias
      *
-     * @param string $field
+     * @param string $column
      * @param string $alias
      * @return Select
      */
-    final public function distinctAs(string $field, string $alias): self
+    final public function distinctAs(string $column, string $alias): self
     {
         $this->distinct = true;
-        return $this->selectAs($field, $alias);
+        return $this->selectAs($column, $alias);
     }
 
     /**
-     * SELECT an aggregated DISTINCT field
+     * SELECT an aggregated DISTINCT column
      *
-     * @param string $field
+     * @param string $column
      * @param string $aggregateFunction
      * @param string $alias
      * @return Select
      */
-    final public function distinctAggregate(string $field, string $aggregateFunction, string $alias): self
+    final public function distinctAggregate(string $column, string $aggregateFunction, string $alias): self
     {
-        if (!$this->isValidSqlName($field)) {
-            throw new InvalidSqlFieldNameException($field);
+        if (!$this->isValidSqlName($column)) {
+            throw new InvalidSqlColumnNameException('SELECT', $column);
         }
 
         if (!AggregateFunctions::isValidValue($aggregateFunction)) {
@@ -181,10 +180,10 @@ class Select extends Query
         }
 
         if (!$this->isValidSqlName($alias)) {
-            throw new InvalidSqlAliasNameException($field, $alias);
+            throw new InvalidSqlAliasNameException($column, $alias);
         }
 
-        $this->select[] = $aggregateFunction . '(DISTINCT ' . $field . ') AS ' . $alias;
+        $this->select[] = $aggregateFunction . '(DISTINCT ' . $column . ') AS ' . $alias;
         return $this;
     }
 

--- a/src/Select.php
+++ b/src/Select.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace Girgias\QueryBuilder;
+
+use Girgias\QueryBuilder\Exceptions\InvalidSqlAliasNameException;
+use Girgias\QueryBuilder\Exceptions\InvalidSqlColumnNameException;
+use Girgias\QueryBuilder\Exceptions\InvalidSqlFieldNameException;
+use Girgias\QueryBuilder\Exceptions\UnexpectedSqlFunctionException;
+use InvalidArgumentException;
+use OutOfRangeException;
+
+class Select extends Query
+{
+    /**
+     * @var ?string
+     */
+    private $tableAlias;
+
+    /**
+     * @var ?array<int, string>
+     */
+    private $select;
+
+    /**
+     * @var bool
+     */
+    private $distinct = false;
+
+    /**
+     * @var ?array<int, string>
+     */
+    private $group;
+
+    /**
+     * @var ?array<int, string>
+     */
+    private $order;
+
+    /**
+     * @var ?int
+     */
+    private $limit;
+
+    /**
+     * @var ?int
+     */
+    private $offset;
+
+    /**
+     * Set an alias for the table
+     *
+     * @param string $alias
+     * @return Select
+     */
+    final public function tableAlias(string $alias): self
+    {
+        if (!$this->isValidSqlName($alias)) {
+            throw new InvalidSqlAliasNameException('FROM', $alias);
+        }
+        $this->tableAlias = $alias;
+        return $this;
+    }
+
+    /**
+     * SELECT fields
+     *
+     * @param string ...$fields
+     * @return Select
+     */
+    final public function select(string ...$fields): self
+    {
+        foreach ($fields as $field) {
+            if (!$this->isValidSqlName($field)) {
+                throw new InvalidSqlFieldNameException($field);
+            }
+            $this->select[] = $field;
+        }
+        return $this;
+    }
+
+    /**
+     * SELECT a field with an alias
+     *
+     * @param string $field
+     * @param string $alias
+     * @return Select
+     */
+    final public function selectAs(string $field, string $alias): self
+    {
+        if (!$this->isValidSqlName($field)) {
+            throw new InvalidSqlFieldNameException($field);
+        }
+
+        if (!$this->isValidSqlName($alias)) {
+            throw new InvalidSqlAliasNameException($field, $alias);
+        }
+
+        $this->select[] = $field . ' AS ' . $alias;
+        return $this;
+    }
+
+    /**
+     * SELECT an aggregated field
+     *
+     * @param string $field
+     * @param string $aggregateFunction
+     * @param string $alias
+     * @return Select
+     */
+    final public function selectAggregate(string $field, string $aggregateFunction, string $alias): self
+    {
+        if (!$this->isValidSqlName($field)) {
+            throw new InvalidSqlFieldNameException($field);
+        }
+
+        if (!AggregateFunctions::isValidValue($aggregateFunction)) {
+            throw new UnexpectedSqlFunctionException('SELECT with aggregate function', $aggregateFunction);
+        }
+
+        if (!$this->isValidSqlName($alias)) {
+            throw new InvalidSqlAliasNameException($field, $alias);
+        }
+
+        $this->select[] = $aggregateFunction . '(' . $field . ') AS ' . $alias;
+        return $this;
+    }
+
+    final public function selectAll(): self
+    {
+        if (is_null($this->select)) {
+            $this->select = [];
+        }
+
+        array_unshift($this->select, '*');
+        return $this;
+    }
+
+
+    /**
+     * SELECT DISTINCT fields
+     *
+     * @param string ...$fields
+     * @return Select
+     */
+    final public function distinct(string ...$fields): self
+    {
+        $this->distinct = true;
+        return $this->select(...$fields);
+    }
+
+    /**
+     * SELECT DISTINCT a field with an alias
+     *
+     * @param string $field
+     * @param string $alias
+     * @return Select
+     */
+    final public function distinctAs(string $field, string $alias): self
+    {
+        $this->distinct = true;
+        return $this->selectAs($field, $alias);
+    }
+
+    /**
+     * SELECT an aggregated DISTINCT field
+     *
+     * @param string $field
+     * @param string $aggregateFunction
+     * @param string $alias
+     * @return Select
+     */
+    final public function distinctAggregate(string $field, string $aggregateFunction, string $alias): self
+    {
+        if (!$this->isValidSqlName($field)) {
+            throw new InvalidSqlFieldNameException($field);
+        }
+
+        if (!AggregateFunctions::isValidValue($aggregateFunction)) {
+            throw new UnexpectedSqlFunctionException('SELECT DISTINCT with aggregate function', $aggregateFunction);
+        }
+
+        if (!$this->isValidSqlName($alias)) {
+            throw new InvalidSqlAliasNameException($field, $alias);
+        }
+
+        $this->select[] = $aggregateFunction . '(DISTINCT ' . $field . ') AS ' . $alias;
+        return $this;
+    }
+
+    /**
+     * Add a GROUP BY clause to the Query
+     *
+     * @param string $column
+     * @return Select
+     */
+    final public function group(string $column): self
+    {
+        if (!$this->isValidSqlName($column)) {
+            throw new InvalidSqlColumnNameException('GROUP BY', $column);
+        }
+
+        $this->group = [$column];
+        return $this;
+    }
+
+    /**
+     * Add an ORDER BY clause to the Query
+     *
+     * @param string $column
+     * @param string $order
+     * @return Select
+     */
+    final public function order(string $column, string $order = self::SORT_ASC): self
+    {
+        if (!$this->isValidSqlName($column)) {
+            throw new InvalidSqlColumnNameException('ORDER BY', $column);
+        }
+        if ($order !== self::SORT_ASC && $order !== self::SORT_DESC) {
+            throw new InvalidArgumentException('Order must be ' . self::SORT_ASC . ' or ' . self::SORT_DESC);
+        }
+
+        $this->order[] = $column . ' ' . $order;
+        return $this;
+    }
+
+    /**
+     * Add a LIMIT clause to the Query
+     *
+     * @param int $limit
+     * @param int|null $offset
+     * @return Select
+     */
+    final public function limit(int $limit, ?int $offset = null): self
+    {
+        if ($limit < 0) {
+            throw new OutOfRangeException('SQL LIMIT can\'t be less than 0');
+        }
+        $this->limit = $limit;
+        if (!is_null($offset)) {
+            $this->offset($offset);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an OFFSET clause to the Query
+     *
+     * @param int $offset
+     */
+    final private function offset(int $offset): void
+    {
+        if ($offset < 0) {
+            throw new OutOfRangeException('SQL OFFSET can\'t be less than 0');
+        }
+        $this->offset = $offset;
+    }
+
+
+    /**
+     * Build SELECT query from parameters
+     *
+     * @return string
+     */
+    final public function getQuery(): string
+    {
+        if (is_null($this->select)) {
+            $this->select[] = '*';
+        }
+        $parts = ['SELECT'];
+        if ($this->distinct) {
+            $parts[] = 'DISTINCT';
+        }
+        $parts[] = join(', ', $this->select);
+
+        $parts[] = 'FROM';
+        $parts[] = $this->table;
+
+        if (!is_null($this->tableAlias)) {
+            $parts[] = 'AS';
+            $parts[] = $this->tableAlias;
+        }
+
+        if (!is_null($this->where)) {
+            $parts[] = 'WHERE';
+            $parts[] = join(' AND ', $this->where);
+        }
+
+        if (!is_null($this->group)) {
+            $parts[] = 'GROUP BY';
+            $parts[] = join(' ', $this->group);
+        }
+
+        if (!is_null($this->having)) {
+            $parts[] = 'HAVING';
+            $parts[] = join(' AND ', $this->having);
+        }
+
+        if (!is_null($this->order)) {
+            $parts[] = 'ORDER BY';
+            $parts[] = join(', ', $this->order);
+        }
+
+        if (!is_null($this->limit)) {
+            $parts[] = 'LIMIT';
+            $parts[] = $this->limit;
+
+            if (!is_null($this->offset)) {
+                $parts[] = 'OFFSET';
+                $parts[] = $this->offset;
+            }
+        }
+
+        return join(' ', $parts);
+    }
+}

--- a/src/Select.php
+++ b/src/Select.php
@@ -2,6 +2,8 @@
 
 namespace Girgias\QueryBuilder;
 
+use Girgias\QueryBuilder\Enums\AggregateFunctions;
+use Girgias\QueryBuilder\Enums\SqlOperators;
 use Girgias\QueryBuilder\Exceptions\DangerousSqlQueryWarning;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlAliasNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlColumnNameException;

--- a/src/Select.php
+++ b/src/Select.php
@@ -2,6 +2,7 @@
 
 namespace Girgias\QueryBuilder;
 
+use Girgias\QueryBuilder\Exceptions\DangerousSqlQueryWarning;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlAliasNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlColumnNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlFieldNameException;
@@ -264,6 +265,13 @@ class Select extends Query
      */
     final public function getQuery(): string
     {
+        if (!is_null($this->limit) && is_null($this->order)) {
+            throw new DangerousSqlQueryWarning(
+                'When using LIMIT, it is important to use an ORDER BY clause that constrains the result rows ' .
+                'into a unique order. Otherwise you will get an unpredictable subset of the query\'s rows.'
+            );
+        }
+
         if (is_null($this->select)) {
             $this->select[] = '*';
         }

--- a/src/Update.php
+++ b/src/Update.php
@@ -1,0 +1,39 @@
+<?php
+namespace Girgias\QueryBuilder;
+
+use Girgias\QueryBuilder\Exceptions\DangerousSqlQueryWarning;
+use RuntimeException;
+
+class Update extends Query
+{
+    /**
+     * Return built Query
+     *
+     * @return string
+     */
+    public function getQuery(): string
+    {
+        if (is_null($this->parameter)) {
+            throw new RuntimeException("No fields to update defined");
+        }
+        if (is_null($this->where)) {
+            throw new DangerousSqlQueryWarning('No WHERE clause in UPDATE query');
+        }
+
+        $parts = ['UPDATE'];
+        $parts[] = $this->table;
+        $parts[] = 'SET';
+
+        $columns = [];
+
+        foreach ($this->parameter as $column => $binding) {
+            $columns[] = $column . ' = :' . $binding;
+        }
+        $parts[] = join(', ', $columns);
+
+        $parts[] = 'WHERE';
+        $parts[] = join(' AND ', $this->where);
+
+        return join(' ', $parts);
+    }
+}

--- a/src/Update.php
+++ b/src/Update.php
@@ -14,7 +14,7 @@ class Update extends Query
     public function getQuery(): string
     {
         if (is_null($this->parameter)) {
-            throw new RuntimeException("No fields to update defined");
+            throw new RuntimeException('No fields to update defined');
         }
         if (is_null($this->where)) {
             throw new DangerousSqlQueryWarning('No WHERE clause in UPDATE query');

--- a/tests/CheckSqlNamesTest.php
+++ b/tests/CheckSqlNamesTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Girgias\Tests\QueryBuilder;
 
-use Girgias\QueryBuilder\Query;
+use Girgias\QueryBuilder\Select;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -9,7 +9,7 @@ class CheckSqlNamesTest extends TestCase
 {
     public function testIsValidSqlName()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'demo'));
+        $query = (new Select('demo'));
         $method = new ReflectionMethod($query, 'isValidSqlName');
         $method->setAccessible(true);
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -2,11 +2,11 @@
 
 namespace Girgias\Tests\QueryBuilder;
 
-use Girgias\QueryBuilder\AggregateFunctions;
+use Girgias\QueryBuilder\Enums\AggregateFunctions;
+use Girgias\QueryBuilder\Enums\SqlOperators;
 use Girgias\QueryBuilder\Delete;
 use Girgias\QueryBuilder\Insert;
 use Girgias\QueryBuilder\Select;
-use Girgias\QueryBuilder\SqlOperators;
 use Girgias\QueryBuilder\Update;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -3,232 +3,332 @@
 namespace Girgias\Tests\QueryBuilder;
 
 use Girgias\QueryBuilder\AggregateFunctions;
-use Girgias\QueryBuilder\Query;
+use Girgias\QueryBuilder\Delete;
+use Girgias\QueryBuilder\Insert;
+use Girgias\QueryBuilder\Select;
 use Girgias\QueryBuilder\SqlOperators;
+use Girgias\QueryBuilder\Update;
 use PHPUnit\Framework\TestCase;
 
 class QueryTest extends TestCase
 {
     public function test__Delete__Query()
     {
-        $query = (new Query(Query::QUERY_DELETE, 'posts'))
-            ->where('id', SqlOperators::EQUAL, 'id');
-        $this->assertEquals('DELETE FROM posts WHERE id = :id', $query->getQuery());
+        $query = (new Delete("posts"))
+            ->where("id", SqlOperators::EQUAL, "id")
+            ->getQuery();
+
+        $this->assertEquals("DELETE FROM posts WHERE id = :id", $query);
     }
 
     public function test__Insert__Query__With__One__Parameter()
     {
-        $query = (new Query(Query::QUERY_INSERT, 'posts'))
-            ->where('id', SqlOperators::EQUAL, 'id')
-            ->bindField('username', 'username');
-        $this->assertEquals('INSERT INTO posts (username) VALUES (:username)', $query->getQuery());
+        $query = (new Insert("posts"))
+            ->where("id", SqlOperators::EQUAL, "id")
+            ->bindField("username", "username")
+            ->getQuery();
+
+        $this->assertEquals("INSERT INTO posts (username) VALUES (:username)", $query);
     }
 
     public function test__Insert__Query__With__Two__Parameter()
     {
-        $query = (new Query(Query::QUERY_INSERT, 'posts'))
-            ->bindField('username', 'username')
-            ->bindField('age', 'age');
-        $this->assertEquals('INSERT INTO posts (username, age) VALUES (:username, :age)', $query->getQuery());
+        $query = (new Insert("posts"))
+            ->bindField("username", "username")
+            ->bindField("age", "age")
+            ->getQuery();
+
+        $this->assertEquals("INSERT INTO posts (username, age) VALUES (:username, :age)", $query);
     }
 
     public function test__Update__Query__With__One__Parameter()
     {
-        $query = (new Query(Query::QUERY_UPDATE, 'posts'))
-            ->where('id', SqlOperators::EQUAL, 'id')
-            ->bindField('username', 'username');
-        $this->assertEquals('UPDATE posts SET username = :username WHERE id = :id', $query->getQuery());
+        $query = (new Update("posts"))
+            ->where("id", SqlOperators::EQUAL, "id")
+            ->bindField("username", "username")
+            ->getQuery();
+
+        $this->assertEquals("UPDATE posts SET username = :username WHERE id = :id", $query);
     }
 
     public function test__Update__Query__With__Two__Parameter()
     {
-        $query = (new Query(Query::QUERY_UPDATE, 'posts'))
-            ->where('id', SqlOperators::EQUAL, 'id')
-            ->bindField('username', 'username')
-            ->bindField('age', 'age');
-        $this->assertEquals('UPDATE posts SET username = :username, age = :age WHERE id = :id', $query->getQuery());
+        $query = (new Update("posts"))
+            ->where("id", SqlOperators::EQUAL, "id")
+            ->bindField("username", "username")
+            ->bindField("age", "age")
+            ->getQuery();
+
+        $this->assertEquals("UPDATE posts SET username = :username, age = :age WHERE id = :id", $query);
     }
 
     /** SELECT QUERIES */
     public function test__Simple__Select__Query()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->select('title');
-        $this->assertEquals('SELECT title FROM posts', $query->getQuery());
+        $query = (new Select("posts"))
+            ->select("title")
+            ->getQuery();
+
+        $this->assertEquals("SELECT title FROM posts", $query);
     }
 
     public function test__Query__Select()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'));
-        $this->assertEquals('SELECT * FROM posts', $query->getQuery());
+        $query = (new Select("posts"))->getQuery();
+
+        $this->assertEquals("SELECT * FROM posts", $query);
     }
 
     public function test__Query__Multiple__Select()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->select('title', 'category');
-        $this->assertEquals('SELECT title, category FROM posts', $query->getQuery());
+        $query = (new Select("posts"))
+            ->select("title", "category")
+            ->getQuery();
+
+        $this->assertEquals("SELECT title, category FROM posts", $query);
+    }
+
+    public function test__Query__Select__All()
+    {
+        $query = (new Select("posts"))
+            ->selectAll()
+            ->getQuery();
+
+        $this->assertEquals("SELECT * FROM posts", $query);
+    }
+
+    public function test__Query__Select__All__With__An__Alias__Select()
+    {
+        $query = (new Select("posts"))
+            ->selectAs("title", "t")
+            ->selectAll()
+            ->getQuery();
+
+        $this->assertEquals("SELECT *, title AS t FROM posts", $query);
     }
 
     public function test__Query__Select__Column__Alias()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-        ->selectAs('title', 't');
-        $this->assertEquals('SELECT title AS t FROM posts', $query->getQuery());
+        $query = (new Select("posts"))
+            ->selectAs("title", "t")
+            ->getQuery();
+
+        $this->assertEquals("SELECT title AS t FROM posts", $query);
     }
 
     public function test__Query__Multiple__Distinct()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->distinct('title', 'category');
-        $this->assertEquals('SELECT DISTINCT title, category FROM posts', $query->getQuery());
+        $query = (new Select("posts"))
+            ->distinct("title", "category")
+            ->getQuery();
+
+        $this->assertEquals("SELECT DISTINCT title, category FROM posts", $query);
     }
 
     public function test__Query__Distinct__Column__Alias()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->distinctAs('title', 't');
-        $this->assertEquals('SELECT DISTINCT title AS t FROM posts', $query->getQuery());
+        $query = (new Select("posts"))
+            ->distinctAs("title", "t")
+            ->getQuery();
+
+        $this->assertEquals("SELECT DISTINCT title AS t FROM posts", $query);
     }
 
     public function test__Select__Aggregate()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->selectAggregate('title', AggregateFunctions::COUNT, 'nb_titles');
-        $this->assertEquals('SELECT COUNT(title) AS nb_titles FROM posts', $query->getQuery());
+        $query = (new Select("posts"))
+            ->selectAggregate("title", AggregateFunctions::COUNT, "nb_titles")
+            ->getQuery();
+
+        $this->assertEquals("SELECT COUNT(title) AS nb_titles FROM posts", $query);
     }
 
     public function test__Select__Aggregate__and__normal__select()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->selectAggregate('title', AggregateFunctions::COUNT, 'nb_titles')
-            ->select('category');
-        $this->assertEquals('SELECT COUNT(title) AS nb_titles, category FROM posts', $query->getQuery());
+        $query = (new Select("posts"))
+            ->selectAggregate("title", AggregateFunctions::COUNT, "nb_titles")
+            ->select("category")
+            ->getQuery();
+
+        $this->assertEquals("SELECT COUNT(title) AS nb_titles, category FROM posts", $query);
     }
 
     public function test__Select__Aggregate__Distinct()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->distinctAggregate('title', AggregateFunctions::COUNT, 'nb_titles');
-        $this->assertEquals('SELECT COUNT(DISTINCT title) AS nb_titles FROM posts', $query->getQuery());
+        $query = (new Select("posts"))
+            ->distinctAggregate("title", AggregateFunctions::COUNT, "nb_titles")
+            ->getQuery();
+
+        $this->assertEquals("SELECT COUNT(DISTINCT title) AS nb_titles FROM posts", $query);
     }
 
     public function test__Select__Aggregate__Distinct__and__normal__select()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->distinctAggregate('title', AggregateFunctions::COUNT, 'nb_titles')
-            ->select('category');
-        $this->assertEquals('SELECT COUNT(DISTINCT title) AS nb_titles, category FROM posts', $query->getQuery());
+        $query = (new Select("posts"))
+            ->distinctAggregate("title", AggregateFunctions::COUNT, "nb_titles")
+            ->select("category")
+            ->getQuery();
+
+        $this->assertEquals("SELECT COUNT(DISTINCT title) AS nb_titles, category FROM posts", $query);
     }
 
-    /** SELECT CLAUSES */
     public function test__Query__Where__Or()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->where('author', SqlOperators::EQUAL, 'demo1')
-            ->whereOr('author', SqlOperators::EQUAL, 'demo2');
-        $this->assertEquals('SELECT * FROM posts WHERE (author = :demo1 OR author = :demo2)', $query->getQuery());
+        $query = (new Select("posts"))
+            ->where("author", SqlOperators::EQUAL, "demo1")
+            ->whereOr("author", SqlOperators::EQUAL, "demo2")
+            ->getQuery();
+
+        $this->assertEquals("SELECT * FROM posts WHERE (author = :demo1 OR author = :demo2)", $query);
     }
 
     public function test__Query__Where_And__Or()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->where('author', SqlOperators::EQUAL, 'demo1')
-            ->whereOr('author', SqlOperators::EQUAL, 'demo2')
-            ->where('published', SqlOperators::EQUAL, 'status');
+        $query = (new Select("posts"))
+            ->where("author", SqlOperators::EQUAL, "demo1")
+            ->whereOr("author", SqlOperators::EQUAL, "demo2")
+            ->where("published", SqlOperators::EQUAL, "status")
+            ->getQuery();
+
         $this->assertEquals(
-            'SELECT * FROM posts WHERE (author = :demo1 OR author = :demo2) AND published = :status',
-            $query->getQuery()
+            "SELECT * FROM posts WHERE (author = :demo1 OR author = :demo2) AND published = :status",
+            $query
         );
     }
 
     public function test__Query__Where__Not__Like__With__Escape__Char()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->whereNotLike('tags', '%UTF#_8', '#');
-        $this->assertEquals("SELECT * FROM posts WHERE tags NOT LIKE '%UTF#_8' ESCAPE '#'", $query->getQuery());
+        $query = (new Select("posts"))
+            ->whereNotLike("tags", "%UTF#_8", "#")
+            ->getQuery();
+
+        $this->assertEquals("SELECT * FROM posts WHERE tags NOT LIKE '%UTF#_8' ESCAPE '#'", $query);
     }
 
     public function test__Query__Where__Between__Integers()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->whereBetween('field', 5, 10);
-        $this->assertEquals('SELECT * FROM posts WHERE field BETWEEN 5 AND 10', $query->getQuery());
+        $query = (new Select("posts"))
+            ->whereBetween("field", 5, 10)
+            ->getQuery();
+
+        $this->assertEquals("SELECT * FROM posts WHERE field BETWEEN 5 AND 10", $query);
     }
     public function test__Query__Where__Between__Dates()
     {
-        $startDate = new \DateTime('01/01/2016');
-        $endDate = new \DateTime('01/01/2017');
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->whereBetween('field', $startDate, $endDate);
+        $startDate = new \DateTime("01/01/2016");
+        $endDate = new \DateTime("01/01/2017");
+        $query = (new Select("posts"))
+            ->whereBetween("field", $startDate, $endDate)
+            ->getQuery();
+
         $this->assertEquals(
-            'SELECT * FROM posts WHERE field BETWEEN \'2016-01-01 00:00:00\' AND \'2017-01-01 00:00:00\'',
-            $query->getQuery()
+            "SELECT * FROM posts WHERE field BETWEEN '2016-01-01 00:00:00' AND '2017-01-01 00:00:00'",
+            $query
         );
     }
 
     public function test__Query__Where__Not__Between__Integers()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->whereNotBetween('field', 5, 10);
-        $this->assertEquals('SELECT * FROM posts WHERE field NOT BETWEEN 5 AND 10', $query->getQuery());
+        $query = (new Select("posts"))
+            ->whereNotBetween("field", 5, 10)
+            ->getQuery();
+
+        $this->assertEquals("SELECT * FROM posts WHERE field NOT BETWEEN 5 AND 10", $query);
     }
 
     public function test__Query__Where__Not__Between__Dates()
     {
-        $startDate = new \DateTime('01/01/2016');
-        $endDate = new \DateTime('01/01/2017');
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->whereNotBetween('field', $startDate, $endDate);
+        $startDate = new \DateTime("01/01/2016");
+        $endDate = new \DateTime("01/01/2017");
+        $query = (new Select("posts"))
+            ->whereNotBetween("field", $startDate, $endDate)
+            ->getQuery();
+
         $this->assertEquals(
-            'SELECT * FROM posts WHERE field NOT BETWEEN \'2016-01-01 00:00:00\' AND \'2017-01-01 00:00:00\'',
-            $query->getQuery()
+            "SELECT * FROM posts WHERE field NOT BETWEEN '2016-01-01 00:00:00' AND '2017-01-01 00:00:00'",
+            $query
         );
     }
 
     public function test__Query__Having__Or()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'demo'))
-            ->having('score', AggregateFunctions::MAX, SqlOperators::MORE_THAN_OR_EQUAL, 500)
-            ->havingOr('score', AggregateFunctions::AVERAGE, SqlOperators::MORE_THAN, 200);
-        $this->assertEquals('SELECT * FROM demo HAVING (MAX(score) >= 500 OR AVG(score) > 200)', $query->getQuery());
+        $query = (new Select("demo"))
+            ->having(
+                "score",
+                AggregateFunctions::MAX,
+                SqlOperators::MORE_THAN_OR_EQUAL,
+                500
+            )
+            ->havingOr(
+                "score",
+                AggregateFunctions::AVERAGE,
+                SqlOperators::MORE_THAN,
+                200
+            )
+            ->getQuery();
+
+        $this->assertEquals("SELECT * FROM demo HAVING (MAX(score) >= 500 OR AVG(score) > 200)", $query);
     }
 
     public function test__Query__Having__And__Or()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'demo'))
-            ->having('score', AggregateFunctions::MAX, SqlOperators::MORE_THAN_OR_EQUAL, 500)
-            ->havingOr('score', AggregateFunctions::AVERAGE, SqlOperators::MORE_THAN, 200)
-            ->having('game_time', AggregateFunctions::MAX, SqlOperators::LESS_THAN, 180);
+        $query = (new Select("demo"))
+            ->having(
+                "score",
+                AggregateFunctions::MAX,
+                SqlOperators::MORE_THAN_OR_EQUAL,
+                500
+            )
+            ->havingOr(
+                "score",
+                AggregateFunctions::AVERAGE,
+                SqlOperators::MORE_THAN,
+                200
+            )
+            ->having(
+                "game_time",
+                AggregateFunctions::MAX,
+                SqlOperators::LESS_THAN,
+                180
+            )
+            ->getQuery();
+
         $this->assertEquals(
-            'SELECT * FROM demo HAVING (MAX(score) >= 500 OR AVG(score) > 200) AND MAX(game_time) < 180',
-            $query->getQuery()
+            "SELECT * FROM demo HAVING (MAX(score) >= 500 OR AVG(score) > 200) AND MAX(game_time) < 180",
+            $query
         );
     }
 
     public function test__Query__Select__With__Most__Methods()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'))
-            ->tableAlias('p')
-            ->distinct('title')
+        $query = (new Select("posts"))
+            ->tableAlias("p")
+            ->distinct("title")
             ->limit(15, 5)
-            ->where('published', SqlOperators::EQUAL, 'status')
-            ->having('score', AggregateFunctions::AVERAGE, SqlOperators::MORE_THAN, 20)
-            ->whereLike('author', "John%")
-            ->order('date_creation')
-            ->group('id');
+            ->where("published", SqlOperators::EQUAL, "status")
+            ->having(
+                "score",
+                AggregateFunctions::AVERAGE,
+                SqlOperators::MORE_THAN,
+                20
+            )
+            ->whereLike("author", "John%")
+            ->order("date_creation")
+            ->group("id")
+            ->getQuery();
 
         $this->assertEquals(
-            "SELECT DISTINCT title FROM posts AS p WHERE published = :status AND author LIKE 'John%' GROUP BY id HAVING AVG(score) > 20 ORDER BY date_creation ASC LIMIT 15 OFFSET 5",
-            $query->getQuery()
+            "SELECT DISTINCT title FROM posts AS p WHERE published = :status AND author LIKE 'John%' " .
+                "GROUP BY id HAVING AVG(score) > 20 ORDER BY date_creation ASC LIMIT 15 OFFSET 5",
+            $query
         );
     }
 
     public function test__Readme__example__1()
     {
-        $query = (new \Girgias\QueryBuilder\Query('select', 'demo'))
+        $query = (new \Girgias\QueryBuilder\Select("demo"))
             ->limit(10, 20)
-            ->order('published_date')
+            ->order("published_date")
             ->getQuery();
 
         $this->assertEquals(
@@ -239,28 +339,30 @@ class QueryTest extends TestCase
 
     public function test__Readme__example__2()
     {
-        $start = new \DateTime('01/01/2016');
-        $end = new \DateTime('01/01/2017');
-        $query = (new \Girgias\QueryBuilder\Query('select', 'demo'))
-            ->select('title', 'slug')
-            ->selectAs('name_author_post', 'author')
-            ->whereBetween('date_published', $start, $end)
-            ->order('date_published', 'DESC')
+        $start = new \DateTime("01/01/2016");
+        $end = new \DateTime("01/01/2017");
+        $query = (new \Girgias\QueryBuilder\Select("demo"))
+            ->select("title", "slug")
+            ->selectAs("name_author_post", "author")
+            ->whereBetween("date_published", $start, $end)
+            ->order("date_published", "DESC")
             ->limit(25)
             ->getQuery();
 
         $this->assertEquals(
-            "SELECT title, slug, name_author_post AS author FROM demo WHERE date_published BETWEEN '2016-01-01 00:00:00' AND '2017-01-01 00:00:00' ORDER BY date_published DESC LIMIT 25",
+            "SELECT title, slug, name_author_post AS author FROM demo WHERE date_published " .
+                "BETWEEN '2016-01-01 00:00:00' AND '2017-01-01 00:00:00' ORDER BY date_published DESC LIMIT 25",
             $query
         );
     }
 
     public function test__Readme__example__3()
     {
-        $query = (new \Girgias\QueryBuilder\Query('select', 'demo'))
-            ->where('author', '=', 'author')
-            ->whereOr('editor', '=', 'editor')
+        $query = (new \Girgias\QueryBuilder\Select("demo"))
+            ->where("author", "=", "author")
+            ->whereOr("editor", "=", "editor")
             ->getQuery();
+
         $this->assertEquals(
             "SELECT * FROM demo WHERE (author = :author OR editor = :editor)",
             $query
@@ -269,13 +371,15 @@ class QueryTest extends TestCase
 
     public function test__Readme__example__4()
     {
-        $query = (new \Girgias\QueryBuilder\Query(Query::QUERY_UPDATE, 'posts'))
-            ->where('id', SqlOperators::EQUAL, 'id')
-            ->bindField('title', 'title')
-            ->bindField('content', 'content')
-            ->bindField('date_last_edited', 'now_date')->getQuery();
+        $query = (new \Girgias\QueryBuilder\Update("posts"))
+            ->where("id", SqlOperators::EQUAL, "id")
+            ->bindField("title", "title")
+            ->bindField("content", "content")
+            ->bindField("date_last_edited", "now_date")
+            ->getQuery();
+
         $this->assertEquals(
-            'UPDATE posts SET title = :title, content = :content, date_last_edited = :now_date WHERE id = :id',
+            "UPDATE posts SET title = :title, content = :content, date_last_edited = :now_date WHERE id = :id",
             $query
         );
     }

--- a/tests/QueryThrowExceptionsTest.php
+++ b/tests/QueryThrowExceptionsTest.php
@@ -2,11 +2,11 @@
 
 namespace Girgias\Tests\QueryBuilder;
 
-use Girgias\QueryBuilder\AggregateFunctions;
+use Girgias\QueryBuilder\Enums\AggregateFunctions;
+use Girgias\QueryBuilder\Enums\SqlOperators;
 use Girgias\QueryBuilder\Delete;
 use Girgias\QueryBuilder\Insert;
 use Girgias\QueryBuilder\Select;
-use Girgias\QueryBuilder\SqlOperators;
 use Girgias\QueryBuilder\Exceptions\DangerousSqlQueryWarning;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlAliasNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlColumnNameException;

--- a/tests/QueryThrowExceptionsTest.php
+++ b/tests/QueryThrowExceptionsTest.php
@@ -3,7 +3,10 @@
 namespace Girgias\Tests\QueryBuilder;
 
 use Girgias\QueryBuilder\AggregateFunctions;
+use Girgias\QueryBuilder\Delete;
+use Girgias\QueryBuilder\Insert;
 use Girgias\QueryBuilder\Query;
+use Girgias\QueryBuilder\Select;
 use Girgias\QueryBuilder\SqlOperators;
 use Girgias\QueryBuilder\Exceptions\DangerousSqlQueryWarning;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlAliasNameException;
@@ -12,6 +15,7 @@ use Girgias\QueryBuilder\Exceptions\InvalidSqlFieldNameException;
 use Girgias\QueryBuilder\Exceptions\InvalidSqlTableNameException;
 use Girgias\QueryBuilder\Exceptions\UnexpectedSqlFunctionException;
 use Girgias\QueryBuilder\Exceptions\UnexpectedSqlOperatorException;
+use Girgias\QueryBuilder\Update;
 use InvalidArgumentException;
 use OutOfRangeException;
 use PHPUnit\Framework\TestCase;
@@ -23,21 +27,15 @@ class QueryThrowExceptionsTest extends TestCase
     private const INVALID_NAME = '2col';
 
     /* EXCEPTION THROWS */
-    public function test__Throw__Exception__On__Invalid__Query__Type()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        (new Query('InvalidQuery', 'demo'));
-    }
-
     public function test__Throw__Exception__On__Invalid__Table__Name()
     {
         $this->expectException(InvalidSqlTableNameException::class);
-        (new Query(Query::QUERY_SELECT, self::INVALID_NAME));
+        (new Select(self::INVALID_NAME));
     }
 
     public function test__Throw__Exception__On__Invalid__Table__Alias()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlAliasNameException::class);
         $query->tableAlias(self::INVALID_NAME);
     }
@@ -45,84 +43,84 @@ class QueryThrowExceptionsTest extends TestCase
     /** SELECT fields */
     public function test__Throw__Exception__On__Invalid__Select__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlFieldNameException::class);
         $query->select(self::INVALID_NAME);
     }
 
     public function test__Throw__Exception__On__Invalid__Select__As__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlFieldNameException::class);
         $query->selectAs(self::INVALID_NAME, 'alias');
     }
 
     public function test__Throw__Exception__On__Invalid__Select__Alias()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlAliasNameException::class);
         $query->selectAs('demo', self::INVALID_NAME);
     }
 
     public function test__Throw__Exception__On__Invalid__Column__when__Select__Aggregate()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlFieldNameException::class);
         $query->selectAggregate(self::INVALID_NAME, AggregateFunctions::COUNT, 'alias');
     }
 
     public function test__Throw__Exception__On__Invalid__Function__when__Select__Aggregate()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(UnexpectedSqlFunctionException::class);
         $query->selectAggregate('demo', 'not_a_function', 'alias');
     }
 
     public function test__Throw__Exception__On__Invalid__Alias__when__Select__Aggregate()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlAliasNameException::class);
         $query->selectAggregate('demo', AggregateFunctions::COUNT, self::INVALID_NAME);
     }
 
     public function test__Throw__Exception__On__Invalid__Distinct__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlFieldNameException::class);
         $query->distinct(self::INVALID_NAME);
     }
 
     public function test__Throw__Exception__On__Invalid__Distinct__As__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlFieldNameException::class);
         $query->distinctAs(self::INVALID_NAME, 'alias');
     }
 
     public function test__Throw__Exception__On__Invalid__Distinct__Alias()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlAliasNameException::class);
         $query->distinctAs('demo', self::INVALID_NAME);
     }
 
     public function test__Throw__Exception__On__Invalid__Column__when__Distinct__Aggregate()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlFieldNameException::class);
         $query->distinctAggregate(self::INVALID_NAME, AggregateFunctions::COUNT, 'alias');
     }
 
     public function test__Throw__Exception__On__Invalid__Function__when__Distinct__Aggregate()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(UnexpectedSqlFunctionException::class);
         $query->distinctAggregate('demo', 'not_a_function', 'alias');
     }
 
     public function test__Throw__Exception__On__Invalid__Alias__when__Distinct__Aggregate()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlAliasNameException::class);
         $query->distinctAggregate('demo', AggregateFunctions::COUNT, self::INVALID_NAME);
     }
@@ -130,35 +128,35 @@ class QueryThrowExceptionsTest extends TestCase
     /** SELECT CLAUSE */
     public function test__Throw__Exception__On__Invalid__Group__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->group(self::INVALID_NAME);
     }
 
     public function test__Throw__Exception__On__Invalid__Order__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->order(self::INVALID_NAME);
     }
 
     public function test__Throw__Exception__On__Invalid__OrderBy__Order()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidArgumentException::class);
         $query->order('test', 'not a valid order');
     }
 
     public function test__Throw__Exception__On__OutOfRange__Limit()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(OutOfRangeException::class);
         $query->limit(-1);
     }
 
     public function test__Throw__Exception__On__OutOfRange__Offset()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(OutOfRangeException::class);
         $query->limit(5, -1);
     }
@@ -166,108 +164,108 @@ class QueryThrowExceptionsTest extends TestCase
     /** WHERE FUNCTIONS EXCEPTIONS */
     public function test__Throw__Exception__On__Invalid__Where__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->where(self::INVALID_NAME, SqlOperators::EQUAL, 'random');
     }
     public function test__Throw__Exception__On__Undefined__Where__Operator()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(UnexpectedSqlOperatorException::class);
         $query->where('test', 'not an operator', 'random');
     }
     public function test__Throw__Exception__On__Invalid__Where__Or__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->whereOr(self::INVALID_NAME, SqlOperators::EQUAL, 'random');
     }
 
     public function test__Throw__Exception__On__Undefined__Where__Or__Operator()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(UnexpectedSqlOperatorException::class);
         $query->whereOr('test', 'not an operator', 'random');
     }
 
     public function test__Throw__Exception__When__Where__Or__Called__Before__Another__Where__Clause()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(RuntimeException::class);
         $query->whereOr('test', SqlOperators::EQUAL, 'random');
     }
 
     public function test__Throw__Exception__On__Invalid__Where__Like__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->whereLike(self::INVALID_NAME, 'a');
     }
 
     public function test__Throw__Exception__On__Invalid__Where__Not__Like__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->whereNotLike(self::INVALID_NAME, 'a');
     }
 
     public function test__Throw__Exception__On__Invalid__Where__Like__Escape__Char()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'posts'));
+        $query = (new Select('posts'));
         $this->expectException(InvalidArgumentException::class);
         $query->whereNotLike('tags', '%UTF#_8', '##');
     }
 
     public function test__Throw__Exception_On_Invalid__Where__Between__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->whereBetween(self::INVALID_NAME, 1, 10);
     }
 
     public function test__Throw__Exception_On_Invalid__Where__Not__Between__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->whereNotBetween(self::INVALID_NAME, 1, 10);
     }
 
     public function test__Throw__Exception__On__Different__Type__Where__Between__Values()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(TypeError::class);
         $query->whereBetween('demo', 1, (new \DateTime()));
     }
 
     public function test__Throw__Exception__On__Different__Type__Where__Not__Between__Values()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(TypeError::class);
         $query->whereNotBetween('demo', 1, (new \DateTime()));
     }
 
     public function test__Throw__Exception__On__String__Value__Type__Where__Between()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidArgumentException::class);
         $query->whereBetween('demo', 'a', 'd');
     }
     public function test__Throw__Exception__On__String__Value__Type__Where__Not__Between()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidArgumentException::class);
         $query->whereNotBetween('demo', 'a', 'd');
     }
 
     public function test__Throw__Exception__On__Bool__Value__Type__Where__Between()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidArgumentException::class);
         $query->whereBetween('demo', true, false);
     }
     public function test__Throw__Exception__On__Bool__Value__Type__Where__Not__Between()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidArgumentException::class);
         $query->whereNotBetween('demo', true, false);
     }
@@ -275,48 +273,48 @@ class QueryThrowExceptionsTest extends TestCase
     /** HAVING FUNCTION EXCEPTIONS */
     public function test__Throw__Exception__On__Invalid__Having__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->having(self::INVALID_NAME, AggregateFunctions::MAX, SqlOperators::EQUAL, 10);
     }
     public function test__Throw__Exception__On__Undefined__Having__Operator()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(UnexpectedSqlOperatorException::class);
         $query->having('test', AggregateFunctions::MAX, 'not an operator', 10);
     }
 
     public function test__Throw__Exception__On__Undefined__Having__Function()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(UnexpectedSqlFunctionException::class);
         $query->having('test', 'not a function', SqlOperators::EQUAL, 10);
     }
 
     public function test__Throw__Exception__On__Invalid__Having__Or__Column()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(InvalidSqlColumnNameException::class);
         $query->havingOr(self::INVALID_NAME, AggregateFunctions::MAX, SqlOperators::EQUAL, 10);
     }
 
     public function test__Throw__Exception__On__Undefined__Having__Or__Operator()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(UnexpectedSqlOperatorException::class);
         $query->havingOr('test', AggregateFunctions::MAX, 'not an operator', 10);
     }
 
     public function test__Throw__Exception__On__Undefined__Having__Or__Function()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(UnexpectedSqlFunctionException::class);
         $query->havingOr('test', 'not a function', SqlOperators::EQUAL, 10);
     }
 
     public function test__Throw__Exception__When__Having__Or__Called__Before__Another__Having__Clause()
     {
-        $query = (new Query(Query::QUERY_SELECT, 'test'));
+        $query = (new Select('test'));
         $this->expectException(RuntimeException::class);
         $query->havingOr('test', AggregateFunctions::AVERAGE, SqlOperators::MORE_THAN, 200);
     }
@@ -324,7 +322,7 @@ class QueryThrowExceptionsTest extends TestCase
     /** Exception on bindField method */
     public function test__Throw__Exception__On__Invalid__Field__To__Bind()
     {
-        $query = (new Query(Query::QUERY_INSERT, 'test'));
+        $query = (new Insert('test'));
         $this->expectException(InvalidSqlFieldNameException::class);
         $query->bindField(self::INVALID_NAME, 'field');
     }
@@ -332,14 +330,14 @@ class QueryThrowExceptionsTest extends TestCase
     /** Dangerous queries */
     public function test__Throw__Exception__On__Dangerous__Delete__Query()
     {
-        $query = (new Query(Query::QUERY_DELETE, 'test'));
+        $query = (new Delete('test'));
         $this->expectException(DangerousSqlQueryWarning::class);
         $query->getQuery();
     }
 
     public function test__Throw__Exception__On__Dangerous__Update__Query()
     {
-        $query = (new Query(Query::QUERY_UPDATE, 'test'));
+        $query = (new Update('test'));
         $query->bindField('field1', 'field1');
         $this->expectException(DangerousSqlQueryWarning::class);
         $query->getQuery();
@@ -348,7 +346,7 @@ class QueryThrowExceptionsTest extends TestCase
     /** Update Query */
     public function test__Throw__Exception__On__Update__Query__Without__Parameters()
     {
-        $query = (new Query(Query::QUERY_UPDATE, 'posts'))
+        $query = (new Update('posts'))
             ->where('id', SqlOperators::EQUAL, 'id');
         $this->expectException(RuntimeException::class);
         $query->getQuery();
@@ -357,7 +355,7 @@ class QueryThrowExceptionsTest extends TestCase
     /** Insert */
     public function test__Throw__Exception__On__Insert__Query__Without__Parameters()
     {
-        $query = (new Query(Query::QUERY_INSERT, 'posts'));
+        $query = (new Insert('posts'));
         $this->expectException(RuntimeException::class);
         $query->getQuery();
     }

--- a/tests/QueryThrowExceptionsTest.php
+++ b/tests/QueryThrowExceptionsTest.php
@@ -173,6 +173,17 @@ class QueryThrowExceptionsTest extends TestCase
         $this->expectException(UnexpectedSqlOperatorException::class);
         $query->where('test', 'not an operator', 'random');
     }
+
+    public function test__Throw__Exception__With__Help__Message__When__Non__Obvious__NotEqualTo__Operator__Used()
+    {
+        $query = (new Select('test'));
+        $this->expectException(UnexpectedSqlOperatorException::class);
+        $this->expectExceptionMessage(
+            'Comparison operator `!=` provided for WHERE clause is invalid or unsupported.
+Did you mean `<>` (ANSI \'not equal to\' operator) ?'
+        );
+        $query->where('test', '!=', 'random');
+    }
     public function test__Throw__Exception__On__Invalid__Where__Or__Column()
     {
         $query = (new Select('test'));

--- a/tests/QueryThrowExceptionsTest.php
+++ b/tests/QueryThrowExceptionsTest.php
@@ -328,6 +328,13 @@ class QueryThrowExceptionsTest extends TestCase
     }
 
     /** Dangerous queries */
+    public function test__Throw__Exception__On__Select__Limit__Without__Order__Clause()
+    {
+        $query = (new Select('test'))->limit(5);
+        $this->expectException(DangerousSqlQueryWarning::class);
+        $query->getQuery();
+    }
+
     public function test__Throw__Exception__On__Dangerous__Delete__Query()
     {
         $query = (new Delete('test'));

--- a/tests/QueryThrowExceptionsTest.php
+++ b/tests/QueryThrowExceptionsTest.php
@@ -5,7 +5,6 @@ namespace Girgias\Tests\QueryBuilder;
 use Girgias\QueryBuilder\AggregateFunctions;
 use Girgias\QueryBuilder\Delete;
 use Girgias\QueryBuilder\Insert;
-use Girgias\QueryBuilder\Query;
 use Girgias\QueryBuilder\Select;
 use Girgias\QueryBuilder\SqlOperators;
 use Girgias\QueryBuilder\Exceptions\DangerousSqlQueryWarning;
@@ -44,14 +43,14 @@ class QueryThrowExceptionsTest extends TestCase
     public function test__Throw__Exception__On__Invalid__Select__Column()
     {
         $query = (new Select('test'));
-        $this->expectException(InvalidSqlFieldNameException::class);
+        $this->expectException(InvalidSqlColumnNameException::class);
         $query->select(self::INVALID_NAME);
     }
 
     public function test__Throw__Exception__On__Invalid__Select__As__Column()
     {
         $query = (new Select('test'));
-        $this->expectException(InvalidSqlFieldNameException::class);
+        $this->expectException(InvalidSqlColumnNameException::class);
         $query->selectAs(self::INVALID_NAME, 'alias');
     }
 
@@ -65,7 +64,7 @@ class QueryThrowExceptionsTest extends TestCase
     public function test__Throw__Exception__On__Invalid__Column__when__Select__Aggregate()
     {
         $query = (new Select('test'));
-        $this->expectException(InvalidSqlFieldNameException::class);
+        $this->expectException(InvalidSqlColumnNameException::class);
         $query->selectAggregate(self::INVALID_NAME, AggregateFunctions::COUNT, 'alias');
     }
 
@@ -86,14 +85,14 @@ class QueryThrowExceptionsTest extends TestCase
     public function test__Throw__Exception__On__Invalid__Distinct__Column()
     {
         $query = (new Select('test'));
-        $this->expectException(InvalidSqlFieldNameException::class);
+        $this->expectException(InvalidSqlColumnNameException::class);
         $query->distinct(self::INVALID_NAME);
     }
 
     public function test__Throw__Exception__On__Invalid__Distinct__As__Column()
     {
         $query = (new Select('test'));
-        $this->expectException(InvalidSqlFieldNameException::class);
+        $this->expectException(InvalidSqlColumnNameException::class);
         $query->distinctAs(self::INVALID_NAME, 'alias');
     }
 
@@ -107,7 +106,7 @@ class QueryThrowExceptionsTest extends TestCase
     public function test__Throw__Exception__On__Invalid__Column__when__Distinct__Aggregate()
     {
         $query = (new Select('test'));
-        $this->expectException(InvalidSqlFieldNameException::class);
+        $this->expectException(InvalidSqlColumnNameException::class);
         $query->distinctAggregate(self::INVALID_NAME, AggregateFunctions::COUNT, 'alias');
     }
 


### PR DESCRIPTION
Version 0.2 of the library.

Split up all the different query types into their separate classes.
Added a warning when using the LIMIT clause without a GROUP BY
Added a helpful message when trying to use ``!=`` as an operator
Updated BasicEnum to use ``static::class`` instead of ``get_called_class()``
Renamed some variables in functions signature (mostly using columns instead of fields with select queries)